### PR TITLE
Better naming and separation of concerns

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 Metrics/BlockLength:
-  Max: 50
+  Max: 75
 
 Style/GlobalVars:
   Exclude:

--- a/lib/etd_transformer/dataspace/import.rb
+++ b/lib/etd_transformer/dataspace/import.rb
@@ -16,6 +16,22 @@ module EtdTransformer
       # @param [String] department_name The name of the department.
       def initialize(department_name)
         @department_name = department_name
+        setup_filesystem
+      end
+
+      ##
+      # Directory where files are written. Consists of the DATASPACE_IMPORT_BASE
+      # plus department name.
+      def dataspace_import_directory
+        raise 'Error: DATASPACE_IMPORT_BASE is nil' unless ENV['DATASPACE_IMPORT_BASE']
+
+        File.join(ENV['DATASPACE_IMPORT_BASE'], department_name)
+      end
+
+      ##
+      # Ensure the directory where the Dataspace imports will be written
+      def setup_filesystem
+        FileUtils.mkdir_p(dataspace_import_directory)
       end
     end
   end

--- a/lib/etd_transformer/dataspace/submission.rb
+++ b/lib/etd_transformer/dataspace/submission.rb
@@ -1,13 +1,23 @@
 # frozen_string_literal: true
 
 require 'byebug'
-require 'creek'
 require 'fileutils'
 
 module EtdTransformer
   module Dataspace
     # A single thesis, post-processing, ready for import into DataSpace
     class Submission
+      attr_reader :dataspace_import, :id
+
+      def initialize(dataspace_import, id)
+        @dataspace_import = dataspace_import
+        @id = id
+        FileUtils.mkdir_p(directory_path)
+      end
+
+      def directory_path
+        File.join(@dataspace_import.dataspace_import_directory, "submission_#{@id}")
+      end
     end
   end
 end

--- a/lib/etd_transformer/vireo/export.rb
+++ b/lib/etd_transformer/vireo/export.rb
@@ -3,18 +3,20 @@
 require 'byebug'
 require 'creek'
 require 'fileutils'
+require 'etd_transformer'
 
 module EtdTransformer
   module Vireo
     # Senior theses as downloaded from Vireo, one department at a time. A Vireo::Export
     # contains a department, a zipfile, and a metadata spreadsheet in Excel.
     class Export
-      attr_reader :department_name
+      attr_reader :department_name, :dataspace_import
 
       ##
       # @param [String] department_name The name of the department. Must match directory name.
       def initialize(department_name)
         @department_name = department_name
+        @dataspace_import = EtdTransformer::Dataspace::Import.new(department_name)
         load_metadata
       end
 
@@ -25,13 +27,11 @@ module EtdTransformer
       # 2. Adding secondary authors
       # 3. Augmenting metadata with secondary academic programs
       def migrate
-        approved_dir = "#{dataspace_import_directory}/#{@department_name}/Approved"
-        FileUtils.mkdir_p approved_dir
         @metadata.simple_rows.each_with_index do |row, index|
           next if index.zero? # skip the header row
           next unless row['Status'] == 'Approved'
 
-          FileUtils.mkdir_p "#{approved_dir}/submission_#{row['ID']}"
+          FileUtils.mkdir_p "#{@dataspace_import.dataspace_import_directory}/submission_#{row['ID']}"
         end
       end
 

--- a/lib/etd_transformer/vireo/submission.rb
+++ b/lib/etd_transformer/vireo/submission.rb
@@ -10,12 +10,14 @@ module EtdTransformer
                   :student_id,
                   :student_name,
                   :primary_document,
-                  :id
+                  :id,
+                  :dataspace_submission
 
       def initialize(vireo_export:, row:)
         @vireo_export = vireo_export
         @row = row
         parse_row
+        @dataspace_submission = EtdTransformer::Dataspace::Submission.new(@vireo_export.dataspace_import, @id)
       end
 
       ##

--- a/spec/etd_transformer/dataspace/import_spec.rb
+++ b/spec/etd_transformer/dataspace/import_spec.rb
@@ -4,20 +4,35 @@ RSpec.describe EtdTransformer::Dataspace::Import do
   let(:di_department_name) { 'German' }
   let(:di) { described_class.new(di_department_name) }
   let(:vireo_export_directory) { "#{$fixture_path}/mock-downloads" }
-  let(:dataspace_import_directory) { "#{$fixture_path}/mock-exports" }
+  let(:dataspace_import_base) { "#{$fixture_path}/mock-exports" }
 
   around do |example|
     vireo_export_dir_pre_test = ENV['VIREO_EXPORT_DIRECTORY']
-    dataspace_import_dir_pre_test = ENV['DATASPACE_IMPORT_DIRECTORY']
+    dataspace_import_base_pre_test = ENV['DATASPACE_IMPORT_BASE']
     ENV['VIREO_EXPORT_DIRECTORY'] = vireo_export_directory
-    ENV['DATASPACE_IMPORT_DIRECTORY'] = dataspace_import_directory
+    ENV['DATASPACE_IMPORT_BASE'] = dataspace_import_base
     example.run
     ENV['VIREO_EXPORT_DIRECTORY'] = vireo_export_dir_pre_test
-    ENV['DATASPACE_IMPORT_DIRECTORY'] = dataspace_import_dir_pre_test
+    ENV['DATASPACE_IMPORT_BASE'] = dataspace_import_base_pre_test
   end
 
   it 'has a department' do
     expect(di).to be_instance_of(described_class)
     expect(di.department_name).to eq di_department_name
+  end
+
+  it 'has a directory where files are written' do
+    expect(di.dataspace_import_directory).to eq "#{dataspace_import_base}/#{di_department_name}"
+  end
+
+  context 'filesystem setup' do
+    before do
+      FileUtils.rm_rf(Dir["#{dataspace_import_base}/*"])
+    end
+    it 'sets up directory for writing' do
+      expect(File.directory?("#{dataspace_import_base}/#{di_department_name}")).to eq false
+      di.setup_filesystem
+      expect(File.directory?("#{dataspace_import_base}/#{di_department_name}")).to eq true
+    end
   end
 end

--- a/spec/etd_transformer/dataspace/submission_spec.rb
+++ b/spec/etd_transformer/dataspace/submission_spec.rb
@@ -1,8 +1,28 @@
 # frozen_string_literal: true
 
 RSpec.describe EtdTransformer::Dataspace::Submission do
+  let(:di_department_name) { 'German' }
+  let(:di) { EtdTransformer::Dataspace::Import.new(di_department_name) }
+  let(:ds) { described_class.new(di, '8234') }
+  let(:dataspace_import_base) { "#{$fixture_path}/mock-exports" }
+
+  around do |example|
+    dataspace_import_base_pre_test = ENV['DATASPACE_IMPORT_BASE']
+    ENV['DATASPACE_IMPORT_BASE'] = dataspace_import_base
+    example.run
+    ENV['DATASPACE_IMPORT_BASE'] = dataspace_import_base_pre_test
+  end
+
   it 'can be instantiated' do
-    import = described_class.new
-    expect(import).to be_instance_of(described_class)
+    expect(ds).to be_instance_of(described_class)
+  end
+  it 'has a Dataspace::Import object' do
+    expect(ds.dataspace_import).to be_instance_of(EtdTransformer::Dataspace::Import)
+  end
+  it 'has an id' do
+    expect(ds.id).to eq '8234'
+  end
+  it 'makes a directory for itself' do
+    expect(ds.directory_path).to eq "#{di.dataspace_import_directory}/submission_#{ds.id}"
   end
 end

--- a/spec/etd_transformer/vireo/export_spec.rb
+++ b/spec/etd_transformer/vireo/export_spec.rb
@@ -2,19 +2,19 @@
 
 RSpec.describe EtdTransformer::Vireo::Export do
   let(:vireo_export_directory) { "#{$fixture_path}/mock-downloads" }
-  let(:dataspace_import_directory) { "#{$fixture_path}/mock-exports" }
+  let(:dataspace_import_base) { "#{$fixture_path}/mock-exports" }
   let(:ve_department_name) { 'German' }
   let(:ve) { described_class.new(ve_department_name) }
   let(:ve_asset_directory) { "#{vireo_export_directory}/#{ve_department_name}" }
 
   around do |example|
     vireo_export_dir_pre_test = ENV['VIREO_EXPORT_DIRECTORY']
-    dataspace_import_dir_pre_test = ENV['DATASPACE_IMPORT_DIRECTORY']
+    dataspace_import_base_pre_test = ENV['DATASPACE_IMPORT_BASE']
     ENV['VIREO_EXPORT_DIRECTORY'] = vireo_export_directory
-    ENV['DATASPACE_IMPORT_DIRECTORY'] = dataspace_import_directory
+    ENV['DATASPACE_IMPORT_BASE'] = dataspace_import_base
     example.run
     ENV['VIREO_EXPORT_DIRECTORY'] = vireo_export_dir_pre_test
-    ENV['DATASPACE_IMPORT_DIRECTORY'] = dataspace_import_dir_pre_test
+    ENV['DATASPACE_IMPORT_BASE'] = dataspace_import_base_pre_test
   end
 
   it 'has a department' do
@@ -48,14 +48,17 @@ RSpec.describe EtdTransformer::Vireo::Export do
     end
   end
 
-  context 'migrating' do
+  context 'migrating data' do
     before do
-      FileUtils.rm_rf(Dir["#{dataspace_import_directory}/*"])
+      FileUtils.rm_rf(Dir["#{dataspace_import_base}/*"])
+    end
+    it 'has a corresponding Dataspace::Import object' do
+      expect(ve.dataspace_import).to be_instance_of(EtdTransformer::Dataspace::Import)
     end
     it 'makes a data space submission folder for each vireo submission' do
-      expect(File.directory?("#{dataspace_import_directory}/#{ve_department_name}/Approved")).to eq false
+      expect(File.directory?("#{dataspace_import_base}/#{ve_department_name}")).to eq false
       ve.migrate
-      expect(File.directory?("#{dataspace_import_directory}/#{ve_department_name}/Approved")).to eq true
+      expect(File.directory?("#{dataspace_import_base}/#{ve_department_name}")).to eq true
     end
   end
 end

--- a/spec/etd_transformer/vireo/submission_spec.rb
+++ b/spec/etd_transformer/vireo/submission_spec.rb
@@ -52,4 +52,8 @@ RSpec.describe EtdTransformer::Vireo::Submission do
   it 'ensures the original pdf document exists' do
     expect(submission.original_pdf_exists?).to eq true
   end
+
+  it 'creates a Dataspace::Submission object' do
+    expect(submission.dataspace_submission).to be_instance_of(EtdTransformer::Dataspace::Submission)
+  end
 end

--- a/spec/etd_transformer/vireo/submission_spec.rb
+++ b/spec/etd_transformer/vireo/submission_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe EtdTransformer::Vireo::Submission do
   let(:vireo_export_directory) { "#{$fixture_path}/mock-downloads" }
   let(:ve_department_name) { 'German' }
   let(:ve) { EtdTransformer::Vireo::Export.new(ve_department_name) }
-  let(:dataspace_import_directory) { "#{$fixture_path}/mock-exports" }
+  let(:dataspace_import_base) { "#{$fixture_path}/mock-exports" }
   let(:ve_asset_directory) { "#{vireo_export_directory}/#{ve_department_name}" }
   let(:submission) do
     submission = nil
@@ -20,12 +20,12 @@ RSpec.describe EtdTransformer::Vireo::Submission do
 
   around do |example|
     vireo_export_dir_pre_test = ENV['VIREO_EXPORT_DIRECTORY']
-    dataspace_import_dir_pre_test = ENV['DATASPACE_IMPORT_DIRECTORY']
+    dataspace_import_base_pre_test = ENV['DATASPACE_IMPORT_BASE']
     ENV['VIREO_EXPORT_DIRECTORY'] = vireo_export_directory
-    ENV['DATASPACE_IMPORT_DIRECTORY'] = dataspace_import_directory
+    ENV['DATASPACE_IMPORT_BASE'] = dataspace_import_base
     example.run
     ENV['VIREO_EXPORT_DIRECTORY'] = vireo_export_dir_pre_test
-    ENV['DATASPACE_IMPORT_DIRECTORY'] = dataspace_import_dir_pre_test
+    ENV['DATASPACE_IMPORT_BASE'] = dataspace_import_base_pre_test
   end
 
   it 'gets data from a row from Excel' do


### PR DESCRIPTION
* Distinguish between DATASPACE_IMPORT_BASE and dataspace_import_directory (the former is the base dir, the latter contains a department name)
*  A Dataspace::Submission object should be in charge of setting up its own filesystem, for cleaner separation of concerns

Addresses #3 