### PR TITLE
Update dublin_core.xml with Mudd access message

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,7 @@ Metrics/AbcSize:
     - lib/etd_transformer/dataspace/submission.rb
 
 Metrics/BlockLength:
-  Max: 100
+  Max: 115
 
 Metrics/MethodLength:
   Exclude:

--- a/lib/etd_transformer/transformer.rb
+++ b/lib/etd_transformer/transformer.rb
@@ -106,6 +106,14 @@ module EtdTransformer
     end
 
     ##
+    # Take the dublin_core.xml file as provided by vireo, augment it, and add it
+    # to the DataSpace import package
+    def generate_dublin_core(vireo_submission, dataspace_submission)
+      dc_original = vireo_submission.dublin_core_file_path
+      dataspace_submission.write_dublin_core(dc_original, walk_in_access(vireo_submission.netid))
+    end
+
+    ##
     # Load the embargo spreadsheet into memory. We use https://github.com/pythonicrubyist/creek
     # to read data from an excel spreadsheet.
     # @return [Hash]

--- a/lib/etd_transformer/vireo/submission.rb
+++ b/lib/etd_transformer/vireo/submission.rb
@@ -54,6 +54,12 @@ module EtdTransformer
         File.join(source_files_directory, original_pdf)
       end
 
+      ##
+      # The full path to the original dublin_core.xml file
+      def dublin_core_file_path
+        File.join(source_files_directory, 'dublin_core.xml')
+      end
+
       def netid
         @student_email.split('@').first
       end

--- a/spec/etd_transformer/transformer_spec.rb
+++ b/spec/etd_transformer/transformer_spec.rb
@@ -96,6 +96,12 @@ RSpec.describe EtdTransformer::Transformer do
         transformer.generate_metadata_pu(vs, ds)
         expect(File.exist?(destination_path)).to eq true
       end
+      it 'copies the dublin core metadata' do
+        destination_path = File.join(ds.directory_path, 'dublin_core.xml')
+        expect(File.exist?(destination_path)).to eq false
+        transformer.generate_dublin_core(vs, ds)
+        expect(File.exist?(destination_path)).to eq true
+      end
     end
   end
 

--- a/spec/etd_transformer/vireo/submission_spec.rb
+++ b/spec/etd_transformer/vireo/submission_spec.rb
@@ -61,6 +61,13 @@ RSpec.describe EtdTransformer::Vireo::Submission do
     expect(submission.netid).to eq 'jcheon'
   end
 
+  context 'dublin core metadata' do
+    it 'knows the location of the original dublin_core.xml file' do
+      file_path = "#{ve.asset_directory}/DSpaceSimpleArchive/submission_8234/dublin_core.xml"
+      expect(submission.dublin_core_file_path).to eq file_path
+    end
+  end
+
   context 'metadata_pu fields' do
     it 'has a classyear' do
       expect(submission.classyear).to eq '2020'


### PR DESCRIPTION
If indicated by the "Walk In Access" column in the embargo spreadsheet,
add the Mudd walk in access message to the dublin core metadata.

Work toward #6 