### PR TITLE
Match on both netid and thesis title when calculating embargo and Mudd access

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,13 +4,15 @@ Layout/LineLength:
   Max: 135
   Exclude:
     - lib/etd_transformer/transformer.rb
+    - spec/etd_transformer/transformer_spec.rb
+    - spec/etd_transformer/vireo/submission_spec.rb
 
 Metrics/AbcSize:
   Exclude:
     - lib/etd_transformer/dataspace/submission.rb
 
 Metrics/BlockLength:
-  Max: 115
+  Max: 130
 
 Metrics/MethodLength:
   Exclude:

--- a/lib/etd_transformer.rb
+++ b/lib/etd_transformer.rb
@@ -6,6 +6,7 @@ require 'etd_transformer/dataspace/import'
 require 'etd_transformer/dataspace/submission'
 require 'etd_transformer/cli'
 require 'etd_transformer/transformer'
+require 'etd_transformer/embargo_data_point'
 
 ##
 # Transform Princeton senior theses (a.k.a. ETDs -- electronic theses and dissertations).

--- a/lib/etd_transformer/embargo_data_point.rb
+++ b/lib/etd_transformer/embargo_data_point.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module EtdTransformer
+  ##
+  # Given a row from an embargo spreadsheet, make an object we can use to calculate embargo
+  class EmbargoDataPoint
+    attr_reader :netid, :title, :walk_in_access, :years
+
+    ##
+    # @param [Hash] spreadsheet_row - a single row from the embargo spreadsheet
+    def initialize(spreadsheet_row)
+      @netid = spreadsheet_row["Submitted By"].split("|").last.split("\\").last
+      @title = spreadsheet_row["Name"]
+      @walk_in_access = spreadsheet_row["Walk In Access"]
+      @years = spreadsheet_row["Embargo Years"]
+    end
+  end
+end

--- a/lib/etd_transformer/vireo/submission.rb
+++ b/lib/etd_transformer/vireo/submission.rb
@@ -13,7 +13,8 @@ module EtdTransformer
                   :id,
                   :dataspace_submission,
                   :asset_directory,
-                  :certificate_programs
+                  :certificate_programs,
+                  :title
 
       def initialize(asset_directory:, row:)
         @asset_directory = asset_directory
@@ -32,6 +33,7 @@ module EtdTransformer
         @thesis_type = @row['Thesis Type']
         @certificate_programs = [] << @row['Certificate Program']
         @student_email = @row['Student email']
+        @title = @row['Title']
       end
 
       ##

--- a/spec/etd_transformer/dataspace/submission_spec.rb
+++ b/spec/etd_transformer/dataspace/submission_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe EtdTransformer::Dataspace::Submission do
   let(:output_dir) { "#{$fixture_path}/exports" }
   let(:di) { EtdTransformer::Dataspace::Import.new(output_dir, di_department_name) }
   let(:ds) { described_class.new(di, '8234') }
+  let(:vireo_export) { EtdTransformer::Vireo::Export.new("#{$fixture_path}/mock-downloads/German") }
 
   it 'can be instantiated' do
     expect(ds).to be_instance_of(described_class)
@@ -24,6 +25,7 @@ RSpec.describe EtdTransformer::Dataspace::Submission do
     let(:expected_dc_file) { File.join(ds.directory_path, 'dublin_core.xml') }
     before do
       FileUtils.rm_rf(expected_dc_file) if File.exist? expected_dc_file
+      vireo_export.unzip_archive
     end
     it 'writes a dublin core metadata file to the expected location' do
       expect(File.exist?(expected_dc_file)).to eq false

--- a/spec/etd_transformer/embargo_data_point_spec.rb
+++ b/spec/etd_transformer/embargo_data_point_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.describe EtdTransformer::EmbargoDataPoint do
+  let(:spreadsheet_row) do
+    {
+      "Name" => "This is a fake creative writing thesis - Janice Cheon.xml",
+      "Submitted By" => "i:0ǵ.t|adfs 3.0|jcheon",
+      "Created" => "2020-05-08 17:16:37 -0400", "Class Year" => "2020",
+      "Department" => "Creative Writing",
+      "Adviser" => "Devin A. Fore", "Embargo Years" => "5",
+      "Walk In Access" => "Yes", "Initial Review" => "Reviewed",
+      "Adviser Comments Status" => "N/A", "Adviser Comments" => nil,
+      "ODOCReview" => "Approved",
+      "Confirmation Sent" => "Yes", "Approval Notification Sent" => "Yes",
+      "Mudd Status" => "Pending", "Request Type" => "Walk-In Only",
+      "Notify Faculty Adviser" => nil, "Thesis Uploaded" => "No",
+      "Check Thesis Uploaded" => "1", "SetFormLink" => nil,
+      "Item Type" => "Item", "Path" => "our/strar/Requests"
+    }
+  end
+  let(:embargo_data_point) { described_class.new(spreadsheet_row) }
+
+  it 'has the netid' do
+    expect(embargo_data_point.netid).to eq 'jcheon'
+  end
+  it 'has the title' do
+    expect(embargo_data_point.title).to eq spreadsheet_row["Name"]
+  end
+  it 'has the walk in access' do
+    expect(embargo_data_point.walk_in_access).to eq 'Yes'
+  end
+  it 'has the embargo years' do
+    expect(embargo_data_point.years).to eq '5'
+  end
+end

--- a/spec/etd_transformer/transformer_spec.rb
+++ b/spec/etd_transformer/transformer_spec.rb
@@ -140,8 +140,10 @@ RSpec.describe EtdTransformer::Transformer do
   end
 
   context 'mudd walkin status' do
-    it "looks up mudd walkin status based on netid" do
-      expect(transformer.walk_in_access('jcheon')).to eq 'Yes'
+    let(:ds) { transformer.dataspace_submissions.first }
+    let(:vs) { transformer.vireo_export.approved_submissions[ds.id] }
+    it "looks up mudd walkin status based on netid and title" do
+      expect(transformer.walk_in_access(vs.netid, vs.title)).to eq 'Yes'
     end
   end
 end

--- a/spec/etd_transformer/vireo/submission_spec.rb
+++ b/spec/etd_transformer/vireo/submission_spec.rb
@@ -61,6 +61,10 @@ RSpec.describe EtdTransformer::Vireo::Submission do
     expect(submission.netid).to eq 'jcheon'
   end
 
+  it 'has a title' do
+    expect(submission.title).to eq "“Against the Malaise of Time”: Embodied Fragmentation and the Temporalities of the Dada Creaturely, 1919-1937"
+  end
+
   context 'dublin core metadata' do
     it 'knows the location of the original dublin_core.xml file' do
       file_path = "#{ve.asset_directory}/DSpaceSimpleArchive/submission_8234/dublin_core.xml"


### PR DESCRIPTION
A student can have multiple theses, so when we look up the embargo length and the walk-in
access we need to match on both netid and thesis title.

Work toward #47 