### PR TITLE
Normalize ID from spreadsheet

### DIFF
--- a/lib/etd_transformer/vireo/export.rb
+++ b/lib/etd_transformer/vireo/export.rb
@@ -101,9 +101,9 @@ module EtdTransformer
         @metadata.simple_rows.each_with_index do |row, index|
           next if index.zero? # skip the header row
           next unless row['Status'] == 'Approved'
-          raise "This spreadsheet does not have the required ID column" if row['ID'].nil?
 
-          @approved_submissions[row['ID']] = EtdTransformer::Vireo::Submission.new(asset_directory: @asset_directory, row: row)
+          santized_id = row['ID'].to_i.to_s
+          @approved_submissions[santized_id] = EtdTransformer::Vireo::Submission.new(asset_directory: @asset_directory, row: row)
         end
         @approved_submissions
       end

--- a/lib/etd_transformer/vireo/submission.rb
+++ b/lib/etd_transformer/vireo/submission.rb
@@ -28,7 +28,7 @@ module EtdTransformer
         @student_id = @row['Student ID']
         @student_name = @row['Student name']
         @primary_document = @row['Primary document']
-        @id = @row['ID']
+        @id = @row['ID'].to_i.to_s
         @approval_date = @row['Approval date']
         @thesis_type = @row['Thesis Type']
         @certificate_programs = [] << @row['Certificate Program']

--- a/spec/etd_transformer/vireo/export_spec.rb
+++ b/spec/etd_transformer/vireo/export_spec.rb
@@ -27,6 +27,13 @@ RSpec.describe EtdTransformer::Vireo::Export do
         expect { ve.check_spreadsheet_for_required_columns(spreadsheet_with_missing_columns) }.to raise_error EtdTransformer::Vireo::IncompleteSpreadsheetError
       end
     end
+    context 'an id number with appended decimals' do
+      let(:input) { "#{$fixture_path}/mock-downloads/Economics" }
+      it "strips the extra zero" do
+        expect(ve.approved_submissions.first[0]).to eq "9508" # Not 9508.0
+        expect(ve.approved_submissions.first.last.id).to eq "9508"
+      end
+    end
   end
 
   context 'initial file setup' do


### PR DESCRIPTION
Some of the time, the ID number from the spreadsheet gets treated like a
float, and it is coming out as 9508.0 instead of 9508, which breaks the
file matching. To fix this, force the number to an integer, then a string.