### PR TITLE
Refactor to prepare Transformer class

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,8 +3,8 @@ inherit_from: .rubocop_todo.yml
 Layout/LineLength:
   Max: 135
   Exclude:
-    - lib/etd_transformer/transformer.rb
-    - spec/etd_transformer/transformer_spec.rb
+    - lib/etd_transformer/senior_theses_transformer.rb
+    - spec/etd_transformer/senior_thesis_transformer_spec.rb
     - spec/etd_transformer/vireo/submission_spec.rb
     - spec/etd_transformer/vireo/export_spec.rb
 
@@ -22,7 +22,7 @@ Metrics/ClassLength:
 Metrics/MethodLength:
   Exclude:
     - lib/etd_transformer/dataspace/submission.rb
-    - lib/etd_transformer/transformer.rb
+    - lib/etd_transformer/senior_theses_transformer.rb
 
 Style/GlobalVars:
   Exclude:

--- a/lib/etd_transformer.rb
+++ b/lib/etd_transformer.rb
@@ -6,7 +6,7 @@ require 'etd_transformer/vireo/incomplete_spreadsheet_error'
 require 'etd_transformer/dataspace/import'
 require 'etd_transformer/dataspace/submission'
 require 'etd_transformer/cli'
-require 'etd_transformer/transformer'
+require 'etd_transformer/senior_theses_transformer'
 require 'etd_transformer/embargo_data_point'
 
 ##

--- a/lib/etd_transformer/cli.rb
+++ b/lib/etd_transformer/cli.rb
@@ -14,7 +14,7 @@ module EtdTransformer
     def process
       if all_required_options_present?
         output_options
-        EtdTransformer::Transformer.transform(options)
+        EtdTransformer::SeniorThesesTransformer.transform(options)
       else
         output_help_message
       end

--- a/lib/etd_transformer/senior_theses_transformer.rb
+++ b/lib/etd_transformer/senior_theses_transformer.rb
@@ -7,7 +7,7 @@ require 'shellwords'
 module EtdTransformer
   ##
   # Orchestrate the transformation of a Vireo export into something else
-  class Transformer
+  class SeniorThesesTransformer
     attr_reader :input_dir, :output_dir, :department, :vireo_export, :dataspace_import, :embargo_spreadsheet, :collection_handle
 
     # How close must two titles be to each other, in terms of Levenshtein distance,

--- a/lib/etd_transformer/senior_theses_transformer.rb
+++ b/lib/etd_transformer/senior_theses_transformer.rb
@@ -22,11 +22,11 @@ module EtdTransformer
     ##
     # Convenience method for kicking off a transformation.
     # @param [Hash] options
-    # @return [EtdTransformer::Transformer]
+    # @return [EtdTransformer::SeniorThesesTransformer]
     # @example
-    #  EtdTransformer::Transformer.transform(input: '/foo', output: '/bar')
+    #  EtdTransformer::SeniorThesesTransformer.transform(input: '/foo', output: '/bar')
     def self.transform(options)
-      transformer = EtdTransformer::Transformer.new(options)
+      transformer = EtdTransformer::SeniorThesesTransformer.new(options)
       transformer.transform
       transformer
     end

--- a/spec/etd_transformer/cli_spec.rb
+++ b/spec/etd_transformer/cli_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe EtdTransformer::Cli do
 
   context 'with required arguments' do
     before do
-      allow(EtdTransformer::Transformer).to receive(:transform)
+      allow(EtdTransformer::SeniorThesesTransformer).to receive(:transform)
     end
     context 'no spaces in path' do
       it 'has an input directory' do

--- a/spec/etd_transformer/senior_thesis_transformer_spec.rb
+++ b/spec/etd_transformer/senior_thesis_transformer_spec.rb
@@ -2,7 +2,7 @@
 
 require 'pdf-reader'
 
-RSpec.describe EtdTransformer::Transformer do
+RSpec.describe EtdTransformer::SeniorThesesTransformer do
   let(:input_dir) { "#{$fixture_path}/mock-downloads/#{department_name}" }
   let(:department_name) { 'German' }
   let(:output_dir) { "#{$fixture_path}/exports" }


### PR DESCRIPTION
Instead of having a single EtdTransformer::Transformer class, we're going
to need to differentiate between different kinds of transformers. Rename
EtdTransformer::Transformer to EtdTransformer::SeniorThesesTransformer
to be more specific about what this class really does.

Work toward #75 