### PR TITLE
Refactor Dataspace::Import

### DIFF
--- a/lib/etd_transformer/dataspace/import.rb
+++ b/lib/etd_transformer/dataspace/import.rb
@@ -5,32 +5,22 @@ require 'fileutils'
 
 module EtdTransformer
   module Dataspace
-    # A department worth of theses ready for import to Dataspace.
-    # A Dataspace::Import has a department, a directory of Dataspace::Submission
-    # objects, and a metadata spreadsheet in Excel.
+    # A set of theses ready for import to Dataspace.
+    # A Dataspace::Import has a directory of Dataspace::Submission objects.
     class Import
-      attr_reader :output_dir, :department_name
+      attr_reader :output_dir
 
       ##
       # @param [String] output Where files will be written.
-      # @param [String] department_name The name of the department.
-      def initialize(output_dir, department_name)
+      def initialize(output_dir)
         @output_dir = output_dir
-        @department_name = department_name
         setup_filesystem
-      end
-
-      ##
-      # Directory where files are written. Consists of the output_dir
-      # plus department name.
-      def dataspace_import_directory
-        File.join(output_dir, department_name)
       end
 
       ##
       # Ensure the directory where the Dataspace imports will be written
       def setup_filesystem
-        FileUtils.mkdir_p(dataspace_import_directory)
+        FileUtils.mkdir_p(@output_dir)
       end
     end
   end

--- a/lib/etd_transformer/dataspace/submission.rb
+++ b/lib/etd_transformer/dataspace/submission.rb
@@ -20,7 +20,7 @@ module EtdTransformer
       end
 
       def directory_path
-        File.join(@dataspace_import.dataspace_import_directory, "submission_#{@id}")
+        File.join(@dataspace_import.output_dir, "submission_#{@id}")
       end
 
       ##

--- a/lib/etd_transformer/senior_theses_transformer.rb
+++ b/lib/etd_transformer/senior_theses_transformer.rb
@@ -41,7 +41,7 @@ module EtdTransformer
       @collection_handle = options[:collection_handle]
       @department = @input_dir.split('/').last # TODO: input can be anywhere.
       @vireo_export = EtdTransformer::Vireo::Export.new(@input_dir)
-      @dataspace_import = EtdTransformer::Dataspace::Import.new(@output_dir, @department)
+      @dataspace_import = EtdTransformer::Dataspace::Import.new(@output_dir)
       @embargo_data = {}
       @walk_in_data = {}
     end

--- a/spec/etd_transformer/dataspace/import_spec.rb
+++ b/spec/etd_transformer/dataspace/import_spec.rb
@@ -1,28 +1,21 @@
 # frozen_string_literal: true
 
 RSpec.describe EtdTransformer::Dataspace::Import do
-  let(:di_department_name) { 'German' }
-  let(:input_dir) { "#{$fixture_path}/mock-downloads/German" }
-  let(:output_dir) { "#{$fixture_path}/exports" }
-  let(:di) { described_class.new(output_dir, di_department_name) }
-
-  it 'has a department' do
-    expect(di).to be_instance_of(described_class)
-    expect(di.department_name).to eq di_department_name
-  end
+  let(:output_dir) { "#{$fixture_path}/exports/German" }
+  let(:di) { described_class.new(output_dir) }
 
   it 'has a directory where files are written' do
-    expect(di.dataspace_import_directory).to eq "#{output_dir}/#{di_department_name}"
+    expect(di.output_dir).to eq output_dir
   end
 
   context 'filesystem setup' do
     before do
-      FileUtils.rm_rf(Dir["#{output_dir}/*"])
+      FileUtils.rm_rf output_dir
     end
     it 'sets up directory for writing' do
-      expect(File.directory?("#{output_dir}/#{di_department_name}")).to eq false
+      expect(File.directory?(output_dir)).to eq false
       di.setup_filesystem
-      expect(File.directory?("#{output_dir}/#{di_department_name}")).to eq true
+      expect(File.directory?(output_dir)).to eq true
     end
   end
 end

--- a/spec/etd_transformer/dataspace/submission_spec.rb
+++ b/spec/etd_transformer/dataspace/submission_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe EtdTransformer::Dataspace::Submission do
-  let(:di_department_name) { 'German' }
-  let(:output_dir) { "#{$fixture_path}/exports" }
-  let(:di) { EtdTransformer::Dataspace::Import.new(output_dir, di_department_name) }
+  let(:department_name) { 'German' }
+  let(:output_dir) { "#{$fixture_path}/exports/#{department_name}" }
+  let(:di) { EtdTransformer::Dataspace::Import.new(output_dir) }
   let(:ds) { described_class.new(di, '8234') }
   let(:vireo_export) { EtdTransformer::Vireo::Export.new("#{$fixture_path}/mock-downloads/German") }
 
@@ -17,7 +17,7 @@ RSpec.describe EtdTransformer::Dataspace::Submission do
     expect(ds.id).to eq '8234'
   end
   it 'makes a directory for itself' do
-    expect(ds.directory_path).to eq "#{di.output_dir}/#{di_department_name}/submission_#{ds.id}"
+    expect(ds.directory_path).to eq "#{di.output_dir}/submission_#{ds.id}"
   end
 
   context 'dublin_core.xml' do
@@ -69,9 +69,9 @@ RSpec.describe EtdTransformer::Dataspace::Submission do
       expect(ds.metadata_pu).to be_instance_of(Nokogiri::XML::Builder)
     end
     it 'writes the department' do
-      ds.department = di_department_name
+      ds.department = department_name
       pu_department = ds.metadata_pu.doc.xpath('//dcvalue[@element="department"]').text
-      expect(pu_department).to eq di_department_name
+      expect(pu_department).to eq department_name
     end
     it 'writes the classyear' do
       classyear = '1999'

--- a/spec/etd_transformer/senior_thesis_transformer_spec.rb
+++ b/spec/etd_transformer/senior_thesis_transformer_spec.rb
@@ -5,7 +5,7 @@ require 'pdf-reader'
 RSpec.describe EtdTransformer::SeniorThesesTransformer do
   let(:input_dir) { "#{$fixture_path}/mock-downloads/#{department_name}" }
   let(:department_name) { 'German' }
-  let(:output_dir) { "#{$fixture_path}/exports" }
+  let(:output_dir) { "#{$fixture_path}/exports/#{department_name}" }
   let(:embargo_spreadsheet) { "#{$fixture_path}/mock-downloads/embargo_spreadsheet_with_netids.xlsx" }
   let(:collection_handle) { '88435/dsp013n203z151' }
   let(:options) do
@@ -35,7 +35,7 @@ RSpec.describe EtdTransformer::SeniorThesesTransformer do
     end
     it 'has a dataspace import' do
       expect(transformer.dataspace_import).to be_instance_of(EtdTransformer::Dataspace::Import)
-      expect(transformer.dataspace_import.dataspace_import_directory).to eq "#{output_dir}/German"
+      expect(transformer.dataspace_import.output_dir).to eq output_dir
     end
     it 'creates the output_dir if it does not exist yet' do
       expect(Dir.exist?(output_dir)).to eq false
@@ -55,18 +55,18 @@ RSpec.describe EtdTransformer::SeniorThesesTransformer do
   context 'transforming a department' do
     let(:expected_submission_directories) do
       [
-        File.join(output_dir, department_name, 'submission_8234'),
-        File.join(output_dir, department_name, 'submission_8286'),
-        File.join(output_dir, department_name, 'submission_8543'),
-        File.join(output_dir, department_name, 'submission_8658'),
-        File.join(output_dir, department_name, 'submission_8789'),
-        File.join(output_dir, department_name, 'submission_8963')
+        File.join(output_dir, 'submission_8234'),
+        File.join(output_dir, 'submission_8286'),
+        File.join(output_dir, 'submission_8543'),
+        File.join(output_dir, 'submission_8658'),
+        File.join(output_dir, 'submission_8789'),
+        File.join(output_dir, 'submission_8963')
       ]
     end
     it 'makes a directory for every approved submission' do
-      expect(Dir.glob("#{transformer.dataspace_import.dataspace_import_directory}/**")).to eq []
+      expect(Dir.glob("#{transformer.dataspace_import.output_dir}/**")).to eq []
       transformer.dataspace_submissions
-      dirs_on_disk = Dir.glob("#{transformer.dataspace_import.dataspace_import_directory}/**")
+      dirs_on_disk = Dir.glob("#{transformer.dataspace_import.output_dir}/**")
       expect(dirs_on_disk.size).to eq expected_submission_directories.size
       expect(dirs_on_disk & expected_submission_directories == dirs_on_disk).to eq true
     end


### PR DESCRIPTION
There is no inherent reason why a Dataspace::Import needs a department
name, and if we remove that as a requirement we can re-use this class
for processing dissertations.

Work toward #75 