### PR TITLE
Include embargo.lift to be backward compatible

### DIFF
--- a/lib/etd_transformer/dataspace/submission.rb
+++ b/lib/etd_transformer/dataspace/submission.rb
@@ -46,8 +46,8 @@ module EtdTransformer
       end
 
       ##
-      # Given a snippet of dublin core xml, write it to the expected file
-      # @param [String] An XML serialization of dublin core
+      # Given a snippet of xml, write it to the expected file
+      # @param [String] An XML serialization of metadata_pu
       def write_metadata_pu_from_xml(metadata_pu_xml)
         File.write(metadata_pu_path, metadata_pu_xml)
       end

--- a/lib/etd_transformer/proquest/dissertation.rb
+++ b/lib/etd_transformer/proquest/dissertation.rb
@@ -32,6 +32,9 @@ module EtdTransformer
               xml.dcvalue(element: 'embargo', qualifier: 'terms') do
                 xml.text embargo_date
               end
+              xml.dcvalue(element: 'embargo', qualifier: 'lift') do
+                xml.text embargo_date
+              end
             end
           end
         end


### PR DESCRIPTION
Not totally clear why we need embargo.terms and embargo.lift but I'm
adding embargo.lift to match what has previously been happening for
dissertations.

Fixes #76 