### PR TITLE
Mudd message does not render as CDATA

### DIFF
--- a/lib/etd_transformer/proquest/dissertation.rb
+++ b/lib/etd_transformer/proquest/dissertation.rb
@@ -87,9 +87,9 @@ module EtdTransformer
               xml.text "Academic dissertations (#{degree})"
             end
             xml.dcvalue(element: 'relation', qualifier: 'isformatof') do
-              xml.cdata "The Mudd Manuscript Library retains one bound
-              copy of each dissertation.  Search for these copies in the library's
-              main catalog: <a href=http://catalog.princeton.edu>catalog.princeton.edu</a>"
+              xml.text "The Mudd Manuscript Library retains one bound copy of
+              each dissertation.  Search for these copies in the library's main
+              catalog: <a href=http://catalog.princeton.edu>catalog.princeton.edu</a>"
             end
             xml.dcvalue(element: 'publisher') do
               xml.text "Princeton, NJ : Princeton University"


### PR DESCRIPTION
Turn it into regular old text and it seems to display as expected.

Fixes #99 